### PR TITLE
Stabilise multiplayer phase flow

### DIFF
--- a/Jemima-main/src/views/Award.js
+++ b/Jemima-main/src/views/Award.js
@@ -1,31 +1,24 @@
-// /src/views/Marking.js
+// /src/views/Award.js
 //
-// Marking view — timed, two-button verdicts (✓ / ✕), auto-submits at 30s.
-// Scoring model implemented upstream (ScoreStrip): marker gets +1 if verdict matches truth,
-// -1 if wrong, 0 if unmarked (treated here as "unknown").
-//
-// Behaviour:
-// • Shows opponent’s 3 questions and ONLY the opponent’s chosen answer (bold).
-// • Two centred buttons per item: ✓ (“right”), ✕ (“wrong”).
-// • 30s BIG timer badge (top-right of the card). Clock is anchored to room.marking.startAt.
-//   - If missing, host sets it on mount. Everyone counts down from there.
-//   - When 0s: any unselected are auto-filled as "unknown"; we write marking & ack.
-// • Submit early if all 3 are decided; otherwise auto-submit on 0s.
-// • Host flips state → "award" when (a) both acks exist OR (b) global timer reached 0s.
-//
-// Data written:
-//   marking.{role}.{round} = ["right"|"wrong"|"unknown", x3]
-//   markingAck.{role}.{round} = true
-//
-// Navigation:
-//   • On host flip to "award", both clients route to /award?code=...&round=...
-//
-// Visuals: Courier font, centred verdict pair, timer badge at top-right, maths pane pinned.
+// Award phase — show the player’s three questions with ✓ / ✕ markers and arm the next phase.
+// • 30 s timer (bold Courier badge, top-right of card).
+// • Displays only the viewer’s own questions (host → hostItems, guest → guestItems) and their chosen answers.
+// • Host advances flow when the timer elapses:
+//     - Rounds 1–4 → set round+1, countdown.startAt = now + 3000, state:"countdown".
+//     - Round 5     → state:"maths".
+// • ScoreStrip remains mounted globally, so we only worry about per-round display here.
+// • Timer anchor: room.award.startAt (ms epoch). Host writes it once if missing.
 
 import {
-  initFirebase, ensureAuth,
-  roomRef, roundSubColRef, doc,
-  getDoc, updateDoc, onSnapshot, serverTimestamp
+  initFirebase,
+  ensureAuth,
+  roomRef,
+  roundSubColRef,
+  doc,
+  getDoc,
+  onSnapshot,
+  updateDoc,
+  serverTimestamp
 } from "../lib/firebase.js";
 
 import * as MathsPaneMod from "../lib/MathsPane.js";
@@ -35,213 +28,227 @@ const mountMathsPane =
    typeof MathsPaneMod?.default?.mount === "function" ? MathsPaneMod.default.mount :
    null);
 
-const clampCode = s => String(s||"").trim().toUpperCase().replace(/[^A-Z0-9]/g,"").slice(0,3);
-const hp = () => new URLSearchParams((location.hash.split("?")[1]||""));
+const clampCode = (s) => String(s || "").trim().toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 3);
+const hp = () => new URLSearchParams((location.hash.split("?")[1] || ""));
+
+const AWARD_WINDOW_MS = 30_000;
 
 function el(tag, attrs = {}, kids = []) {
-  const n = document.createElement(tag);
+  const node = document.createElement(tag);
   for (const k in attrs) {
     const v = attrs[k];
-    if (k === "class") n.className = v;
-    else if (k.startsWith("on") && typeof v === "function") n.addEventListener(k.slice(2), v);
-    else n.setAttribute(k, v);
+    if (k === "class") node.className = v;
+    else if (k.startsWith("on") && typeof v === "function") node.addEventListener(k.slice(2), v);
+    else node.setAttribute(k, v);
   }
-  (Array.isArray(kids) ? kids : [kids]).forEach(c =>
-    n.appendChild(typeof c === "string" ? document.createTextNode(c) : c)
+  (Array.isArray(kids) ? kids : [kids]).forEach((child) =>
+    node.appendChild(typeof child === "string" ? document.createTextNode(child) : child)
   );
-  return n;
+  return node;
 }
 
-const VERDICT = { RIGHT: "right", WRONG: "wrong", UNKNOWN: "unknown" };
-const MARKING_WINDOW_MS = 30_000;
+function same(a, b) {
+  return String(a || "").trim() === String(b || "").trim();
+}
 
 export default {
-  async mount(container){
+  async mount(container) {
     await initFirebase();
     const me = await ensureAuth();
 
-    const code  = clampCode(hp().get("code") || "");
-    const round = parseInt(hp().get("round") || "1", 10) || 1;
+    const qs = hp();
+    const code = clampCode(qs.get("code") || "");
+    let round = parseInt(qs.get("round") || "1", 10) || 1;
 
-    // Per-view ink hue
-    const hue = Math.floor(Math.random()*360);
+    // per-view hue
+    const hue = Math.floor(Math.random() * 360);
     document.documentElement.style.setProperty("--ink-h", String(hue));
 
-    // Structure
     container.innerHTML = "";
-    const root = el("div", { class:"view view-marking" });
-    root.appendChild(el("h1", { class:"title" }, `Round ${round}`));
+    const root = el("div", { class: "view view-award" });
+    const title = el("h1", { class: "title" }, `Round ${round}`);
+    root.appendChild(title);
 
-    const card = el("div", { class:"card" });
-    const timerBadge = el("div", { class:"timer-badge mono" }, "30");
+    const card = el("div", { class: "card" });
+    const timerBadge = el("div", { class: "timer-badge mono" }, "30");
     card.appendChild(timerBadge);
 
-    const tag = el("div", { class:"mono", style:"text-align:center;margin-bottom:8px;" }, `Room ${code}`);
+    const tag = el("div", { class: "mono", style: "text-align:center;margin-bottom:8px;" }, `Room ${code}`);
     card.appendChild(tag);
 
-    const list = el("div", { class:"qa-list" });
+    const list = el("div", { class: "qa-list" });
     card.appendChild(list);
 
-    container.appendChild(root);
     root.appendChild(card);
 
-    // Maths pinned
-    const mathsMount = el("div", { class:"jemima-maths-pinned" });
+    const mathsMount = el("div", { class: "jemima-maths-pinned" });
     root.appendChild(mathsMount);
 
-    const rRef  = roomRef(code);
-    const r1Ref = doc(roundSubColRef(code), String(round));
+    container.appendChild(root);
 
-    // Resolve role and opponent
+    const rRef = roomRef(code);
+    const rdRef = doc(roundSubColRef(code), String(round));
+
     const roomSnap = await getDoc(rRef);
     const roomData0 = roomSnap.data() || {};
     const { hostUid, guestUid } = roomData0.meta || {};
-    const myRole  = (hostUid === me.uid) ? "host" : (guestUid === me.uid) ? "guest" : "guest";
-    const oppRole = myRole === "host" ? "guest" : "host";
+    const myRole = hostUid === me.uid ? "host" : guestUid === me.uid ? "guest" : "guest";
 
-    // Mount maths if present
-    try { if (mountMathsPane && roomData0.maths) mountMathsPane(mathsMount, { maths: roomData0.maths, round, mode:"inline" }); }
-    catch(e){ console.warn("[marking] MathsPane mount failed:", e); }
+    let awardStartAt = Number(roomData0?.award?.startAt || 0) || 0;
+    let advanced = false;
 
-    // Load round data & opponent answers
-    const rd = (await getDoc(r1Ref)).data() || {};
-    const oppItems   = (oppRole === "host" ? rd.hostItems : rd.guestItems) || [];
-    const oppAnswers = (((roomData0.answers||{})[oppRole]||{})[round]||[]).map(a => a?.chosen || "");
-
-    // Local state
-    let marks = [null, null, null]; // "right" | "wrong" | "unknown"
-    let published = false;
-    let stopRoomWatch = null;
-    let tickHandle = null;
-    let markingStartAt = Number((roomData0.marking && roomData0.marking.startAt) || 0);
-
-    // Host ensures marking.startAt
-    if (!markingStartAt && myRole === "host") {
-      try {
-        markingStartAt = Date.now();
-        await updateDoc(rRef, { "marking.startAt": markingStartAt, "timestamps.updatedAt": serverTimestamp(), state: "marking" });
-      } catch (e) { /* non-fatal; guest may pick up later */ }
+    if (Number(roomData0.round)) {
+      round = Number(roomData0.round);
+      title.textContent = `Round ${round}`;
     }
 
-    // Render a single row
-    function renderRow(i, qText, chosen){
-      const row = el("div", { class:"mark-row" });
-
-      const q = el("div", { class:"q mono" }, `${i+1}. ${qText || "(missing question)"}`);
-      const a = el("div", { class:"a mono" }, chosen || "(no answer recorded)");
-      row.appendChild(q);
-      row.appendChild(a);
-
-      const pair = el("div", { class:"verdict-row" });
-      const bTick  = el("button", { class:"btn outline choice-tick" }, "✓");
-      const bCross = el("button", { class:"btn outline choice-cross" }, "✕");
-
-      const updateStyles = () => {
-        bTick.classList.toggle("active",  marks[i] === VERDICT.RIGHT);
-        bCross.classList.toggle("active", marks[i] === VERDICT.WRONG);
-      };
-
-      bTick.addEventListener("click",  () => { marks[i] = VERDICT.RIGHT;  updateStyles(); maybeSubmitIfComplete(); });
-      bCross.addEventListener("click", () => { marks[i] = VERDICT.WRONG;  updateStyles(); maybeSubmitIfComplete(); });
-
-      pair.appendChild(bTick);
-      pair.appendChild(bCross);
-      row.appendChild(pair);
-      return row;
+    try {
+      if (mountMathsPane && roomData0.maths) {
+        mountMathsPane(mathsMount, { maths: roomData0.maths, round, mode: "inline" });
+      }
+    } catch (err) {
+      console.warn("[award] MathsPane mount failed:", err);
     }
 
-    // Build list
+    const rdSnap = await getDoc(rdRef);
+    const rd = rdSnap.data() || {};
+    const items = (myRole === "host" ? rd.hostItems : rd.guestItems) || [];
+    const answers = (((roomData0.answers || {})[myRole] || {})[round] || []).map((a) => a?.chosen || "");
+
     list.innerHTML = "";
-    for (let i = 0; i < 3; i++) {
-      const q = oppItems[i]?.question || "";
-      const chosen = oppAnswers[i] || "";
-      list.appendChild(renderRow(i, q, chosen));
+    for (let i = 0; i < 3; i += 1) {
+      const q = items[i]?.question || "(missing question)";
+      const chosen = answers[i] || "(no answer)";
+      const correct = items[i]?.correct_answer || "";
+      const truth = correct ? same(chosen, correct) : false;
+
+      const row = el("div", { class: "mark-row" });
+      const qEl = el("div", { class: "q mono" }, `${i + 1}. ${q}`);
+      const aEl = el("div", { class: "a mono" }, chosen);
+
+      const badge = el("span", {
+        class: "mono",
+        style: `margin-left:8px;font-weight:700;${truth ? "color:var(--ok);" : "color:var(--bad);"}`
+      }, truth ? "✓" : "✕");
+      aEl.appendChild(badge);
+
+      row.appendChild(qEl);
+      row.appendChild(aEl);
+
+      if (!truth && correct) {
+        const corr = el("div", { class: "mono small", style: "margin-top:4px;opacity:.8" }, `Correct: ${correct}`);
+        row.appendChild(corr);
+      }
+
+      list.appendChild(row);
     }
 
-    // Submit logic
-    const publish = async () => {
-      if (published) return;
-      published = true;
+    const ensureStartAt = async () => {
+      if (myRole !== "host") return;
+      const now = Date.now();
+      const stale = !awardStartAt || now - awardStartAt > AWARD_WINDOW_MS * 2;
+      if (!stale) return;
 
-      // Fill any still-null with "unknown"
-      marks = marks.map(v => (v === VERDICT.RIGHT || v === VERDICT.WRONG) ? v : VERDICT.UNKNOWN);
+      awardStartAt = Date.now();
+      try {
+        console.log(`[flow] arm award timer | code=${code} round=${round} role=${myRole}`);
+        await updateDoc(rRef, {
+          "award.startAt": awardStartAt,
+          "timestamps.updatedAt": serverTimestamp()
+        });
+      } catch (err) {
+        console.warn("[award] failed to set startAt:", err);
+      }
+    };
 
-      const patch = {};
-      patch[`marking.${myRole}.${round}`]    = marks.slice();
-      patch[`markingAck.${myRole}.${round}`] = true;
-      patch["timestamps.updatedAt"] = serverTimestamp();
+    await ensureStartAt();
+
+    const advance = async () => {
+      if (advanced || myRole !== "host") return;
+      advanced = true;
+
+      const patch = { "timestamps.updatedAt": serverTimestamp(), "award.startAt": null };
+      if (round >= 5) {
+        patch.state = "maths";
+        console.log(`[flow] award -> maths | code=${code} round=${round} role=${myRole}`);
+      } else {
+        const nextRound = round + 1;
+        const nextStart = Date.now() + 3_000;
+        patch.state = "countdown";
+        patch.round = nextRound;
+        patch["countdown.startAt"] = nextStart;
+        console.log(`[flow] award -> countdown | code=${code} round=${round} role=${myRole} next=${nextRound}`);
+      }
 
       try {
         await updateDoc(rRef, patch);
-      } catch (e) {
-        console.warn("[marking] publish failed:", e);
-        published = false; // allow retry by timer or further user action
+      } catch (err) {
+        console.warn("[award] failed to advance:", err);
+        advanced = false; // retry on next tick
       }
     };
 
-    function maybeSubmitIfComplete(){
-      if (!marks.includes(null)) publish(); // all 3 decided -> publish immediately
-    }
+    const stop = onSnapshot(rRef, (snap) => {
+      const data = snap.data() || {};
 
-    // Room watcher: flip to award on both acks OR when global timer hits 0
-    stopRoomWatch = onSnapshot(rRef, async s => {
-      const d = s.data() || {};
-      // (Re-)fetch startAt if it arrives late
-      if (!markingStartAt && d.marking?.startAt) {
-        markingStartAt = Number(d.marking.startAt);
+      if (Number(data.round) && Number(data.round) !== round) {
+        round = Number(data.round);
+        title.textContent = `Round ${round}`;
       }
 
-      // if state has already changed, follow it
-      if (d.state === "award") {
-        setTimeout(()=> location.hash = `#/award?code=${code}&round=${round}`, 80);
+      const remoteStart = Number(data?.award?.startAt || 0) || 0;
+      if (remoteStart && remoteStart !== awardStartAt) {
+        awardStartAt = remoteStart;
+      }
+
+      if (data.state === "countdown") {
+        const nextRound = Number(data.round || round + 1);
+        setTimeout(() => {
+          location.hash = `#/countdown?code=${code}&round=${nextRound}`;
+        }, 100);
         return;
       }
 
-      // Host-only: manage transition
-      if (myRole === "host") {
-        const myAck  = !!(((d.markingAck||{})[myRole]  || {})[round]);
-        const oppAck = !!(((d.markingAck||{})[oppRole] || {})[round]);
-
-        // Compute if timer elapsed (guard if startAt unknown)
-        const now = Date.now();
-        const elapsed = (markingStartAt && (now - markingStartAt >= MARKING_WINDOW_MS));
-
-        if ((myAck && oppAck) || elapsed) {
-          try {
-            await updateDoc(rRef, { state: "award", "timestamps.updatedAt": serverTimestamp() });
-          } catch (e) { /* harmless retry on next tick */ }
-        }
+      if (data.state === "maths") {
+        setTimeout(() => { location.hash = `#/maths?code=${code}`; }, 100);
+        return;
       }
+
+      if (data.state === "final") {
+        setTimeout(() => { location.hash = `#/final?code=${code}`; }, 100);
+        return;
+      }
+
+      if (data.state === "marking") {
+        // If we landed late, go back to marking for this round.
+        setTimeout(() => { location.hash = `#/marking?code=${code}&round=${round}`; }, 100);
+      }
+    }, (err) => {
+      console.warn("[award] snapshot error:", err);
     });
 
-    // Timer tick (visual + auto-submit at 0)
-    tickHandle = setInterval(async () => {
-      const now = Date.now();
-      let remainMs;
-
-      if (!markingStartAt) {
-        // No anchor yet — display waiting tick
+    const tick = setInterval(async () => {
+      if (!awardStartAt) {
         timerBadge.textContent = "—";
+        await ensureStartAt();
         return;
       }
 
-      remainMs = Math.max(0, (markingStartAt + MARKING_WINDOW_MS) - now);
-      const sec = Math.ceil(remainMs / 1000);
-      timerBadge.textContent = String(sec);
+      const now = Date.now();
+      const remainMs = Math.max(0, (awardStartAt + AWARD_WINDOW_MS) - now);
+      const secs = Math.ceil(remainMs / 1000);
+      timerBadge.textContent = String(secs > 0 ? secs : 0);
 
       if (remainMs <= 0) {
-        clearInterval(tickHandle); tickHandle = null;
-        // Auto-publish if we haven't
-        await publish();
-        // Host will flip to award via snapshot watcher; guests will follow
+        await advance();
       }
     }, 200);
 
-    // Unmount
     this.unmount = () => {
-      try { stopRoomWatch && stopRoomWatch(); } catch {}
-      if (tickHandle) { clearInterval(tickHandle); tickHandle = null; }
+      try { stop && stop(); } catch {}
+      try { clearInterval(tick); } catch {}
     };
   },
 
-  async unmount(){ /* router may call instance.unmount */ }
+  async unmount() { /* instance handles cleanup */ }
+};

--- a/Jemima-main/src/views/Countdown.js
+++ b/Jemima-main/src/views/Countdown.js
@@ -1,191 +1,202 @@
-// /src/views/Award.js
+// /src/views/Countdown.js
 //
-// Award view — shows *your* three answers for the round with ✓/✕ truth indicators.
-// • 30s bold timer (top-right of card). On 0s, host advances automatically.
-// • Displays each question, your chosen answer (bold), and a ✓ (correct) or ✕ (incorrect).
-// • No totals shown here; the persistent ScoreStrip handles running scores.
-// • Flow after timeout:
-//     - Rounds 1–4: host sets room.round = round+1, arms a 3s auto countdown, state:"countdown".
-//     - Round 5: host sets state:"maths" (no countdown), strip remains visible.
+// Countdown phase — shared 3·2·1 timer anchored to Firestore.
+// • Shows a bold monospace timer that counts real seconds (3 → 2 → 1 → 0).
+// • Host ensures `countdown.startAt` exists (ms epoch). Guests simply wait for it.
+// • When timer elapses, host flips the room to `state:"questions"`.
+// • Both players navigate to /questions once the room state changes.
 //
-// Inputs: ?code=ABC&round=N
+// Query params: ?code=ABC&round=N
+// Firestore:
+//   READ  rooms/{code} -> meta.hostUid/guestUid, countdown.startAt, state, round
+//   WRITE (host only)
+//     - Arm timer:   countdown.startAt = Date.now()+3000, state:"countdown", round (idempotent)
+//     - On expiry:   state:"questions", countdown.startAt -> null
 //
-// Firestore reads:
-//   rooms/{code}  -> meta(hostUid,guestUid), answers, state, round, maths (for strip consistency)
-//   rooms/{code}/rounds/{round} -> hostItems/guestItems (to compute truth)
-//
-// Writes (host only on timeout or if both clients already arrived here):
-//   - Rounds <5:  countdown.startAt = now + 3000, state:"countdown", round: round+1
-//   - Round ==5:  state:"maths"
-//
-// Visual: Courier, minimal card, timer badge, maths pane pinned below (same as other views)
+// Visual language: Courier, narrow column, minimal card.
 
 import {
-  initFirebase, ensureAuth,
-  roomRef, roundSubColRef, doc,
-  getDoc, updateDoc, onSnapshot, serverTimestamp
+  initFirebase,
+  ensureAuth,
+  roomRef,
+  getDoc,
+  onSnapshot,
+  updateDoc,
+  serverTimestamp
 } from "../lib/firebase.js";
 
-import * as MathsPaneMod from "../lib/MathsPane.js";
-const mountMathsPane =
-  (typeof MathsPaneMod?.default === "function" ? MathsPaneMod.default :
-   typeof MathsPaneMod?.mount === "function" ? MathsPaneMod.mount :
-   typeof MathsPaneMod?.default?.mount === "function" ? MathsPaneMod.default.mount :
-   null);
+const clampCode = (s) => String(s || "").trim().toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 3);
+const hp = () => new URLSearchParams((location.hash.split("?")[1] || ""));
 
-const clampCode = s => String(s||"").trim().toUpperCase().replace(/[^A-Z0-9]/g,"").slice(0,3);
-const hp = () => new URLSearchParams((location.hash.split("?")[1]||""));
+const COUNTDOWN_WINDOW_MS = 3_000;
 
 function el(tag, attrs = {}, kids = []) {
-  const n = document.createElement(tag);
+  const node = document.createElement(tag);
   for (const k in attrs) {
     const v = attrs[k];
-    if (k === "class") n.className = v;
-    else if (k.startsWith("on") && typeof v === "function") n.addEventListener(k.slice(2), v);
-    else n.setAttribute(k, v);
+    if (k === "class") node.className = v;
+    else if (k.startsWith("on") && typeof v === "function") node.addEventListener(k.slice(2), v);
+    else node.setAttribute(k, v);
   }
-  (Array.isArray(kids) ? kids : [kids]).forEach(c =>
-    n.appendChild(typeof c === "string" ? document.createTextNode(c) : c)
+  (Array.isArray(kids) ? kids : [kids]).forEach((child) =>
+    node.appendChild(typeof child === "string" ? document.createTextNode(child) : child)
   );
-  return n;
+  return node;
 }
 
-const AWARD_WINDOW_MS = 30_000;
-
-function same(a,b){ return String(a||"").trim() === String(b||"").trim(); }
-
 export default {
-  async mount(container){
+  async mount(container) {
     await initFirebase();
     const me = await ensureAuth();
 
     const qs = hp();
-    const code  = clampCode(qs.get("code") || "");
-    const round = parseInt(qs.get("round") || "1", 10) || 1;
+    const code = clampCode(qs.get("code") || "");
+    let round = parseInt(qs.get("round") || "1", 10) || 1;
 
-    // per-view ink hue
-    const hue = Math.floor(Math.random()*360);
+    // per-view hue
+    const hue = Math.floor(Math.random() * 360);
     document.documentElement.style.setProperty("--ink-h", String(hue));
 
-    // Skeleton
     container.innerHTML = "";
-    const root = el("div", { class:"view view-award" });
-    root.appendChild(el("h1", { class:"title" }, `Round ${round}`));
+    const root = el("div", { class: "view view-countdown" });
+    const title = el("h1", { class: "title" }, `Round ${round}`);
+    root.appendChild(title);
 
-    const card = el("div", { class:"card" });
-    const timerBadge = el("div", { class:"timer-badge mono" }, "30");
-    card.appendChild(timerBadge);
-
-    const tag = el("div", { class:"mono", style:"text-align:center;margin-bottom:8px;" }, `Room ${code}`);
+    const card = el("div", { class: "card" });
+    const tag = el("div", { class: "mono", style: "text-align:center;margin-bottom:8px;" }, `Room ${code}`);
     card.appendChild(tag);
 
-    const list = el("div", { class:"qa-list" });
-    card.appendChild(list);
+    const msg = el("div", { class: "mono", style: "text-align:center;opacity:.8;margin-bottom:12px;" }, "Get ready…");
+    card.appendChild(msg);
 
-    container.appendChild(root);
+    const timer = el("div", {
+      class: "mono",
+      style: "font-size:64px;line-height:1;text-align:center;font-weight:700;"
+    }, "—");
+    card.appendChild(timer);
+
+    const sub = el("div", { class: "mono small", style: "text-align:center;margin-top:12px;" }, "Waiting for host…");
+    card.appendChild(sub);
+
     root.appendChild(card);
+    container.appendChild(root);
 
-    // Maths pinned (for consistency across views)
-    const mathsMount = el("div", { class:"jemima-maths-pinned" });
-    root.appendChild(mathsMount);
+    const rRef = roomRef(code);
+    const snap0 = await getDoc(rRef);
+    const room0 = snap0.data() || {};
+    const { hostUid, guestUid } = room0.meta || {};
+    const myRole = hostUid === me.uid ? "host" : guestUid === me.uid ? "guest" : "guest";
 
-    // Refs
-    const rRef  = roomRef(code);
-    const r1Ref = doc(roundSubColRef(code), String(round));
+    let countdownStartAt = Number(room0?.countdown?.startAt || 0) || 0;
+    let hasFlipped = false;
 
-    // Room + role
-    const roomSnap = await getDoc(rRef);
-    const roomData0 = roomSnap.data() || {};
-    const { hostUid, guestUid } = roomData0.meta || {};
-    const myRole  = (hostUid === me.uid) ? "host" : (guestUid === me.uid) ? "guest" : "guest";
-    const oppRole = myRole === "host" ? "guest" : "host";
-
-    try { if (mountMathsPane && roomData0.maths) mountMathsPane(mathsMount, { maths: roomData0.maths, round, mode:"inline" }); }
-    catch(e){ console.warn("[award] MathsPane mount failed:", e); }
-
-    // Round data + my answers
-    const rd = (await getDoc(r1Ref)).data() || {};
-    const myItems = (myRole === "host" ? rd.hostItems : rd.guestItems) || [];
-    const myAns   = (((roomData0.answers||{})[myRole]||{})[round]||[]).map(a => a?.chosen || "");
-
-    // Build list with ✓/✕ truth
-    list.innerHTML = "";
-    for (let i = 0; i < 3; i++) {
-      const q = myItems[i]?.question || "(missing question)";
-      const chosen = myAns[i] || "(no answer)";
-      const correct = myItems[i]?.correct_answer || "";
-      const truth = correct && same(chosen, correct);
-
-      const row = el("div", { class:"mark-row" });
-      const qEl = el("div", { class:"q mono" }, `${i+1}. ${q}`);
-      const aEl = el("div", { class:"a mono" }, chosen);
-
-      // truth badge inline at end of answer line
-      const badge = el("span", {
-        class: "mono",
-        style: `margin-left:8px; font-weight:700; ${truth ? "color:var(--ok);" : "color:var(--bad);"}`
-      }, truth ? "✓" : "✕");
-      aEl.appendChild(badge);
-
-      // If wrong, also show the correct answer beneath (subtle)
-      if (!truth && correct) {
-        const corr = el("div", { class:"mono small", style:"margin-top:4px;opacity:.8" }, `Correct: ${correct}`);
-        row.appendChild(qEl); row.appendChild(aEl); row.appendChild(corr);
-      } else {
-        row.appendChild(qEl); row.appendChild(aEl);
-      }
-      list.appendChild(row);
+    // Allow round label to follow doc updates (e.g., if host armed next round before guest arrived)
+    if (Number(room0.round)) {
+      round = Number(room0.round);
+      title.textContent = `Round ${round}`;
     }
 
-    // Watch room to follow state changes
-    const stop = onSnapshot(rRef, s => {
-      const d = s.data() || {};
-      if (d.state === "countdown") {
-        const nextRound = Number(d.round || round + 1);
-        setTimeout(()=> location.hash = `#/countdown?code=${code}&round=${nextRound}`, 100);
-      } else if (d.state === "maths") {
-        setTimeout(()=> location.hash = `#/maths?code=${code}`, 100);
+    const armCountdownIfNeeded = async () => {
+      if (myRole !== "host") return;
+      const now = Date.now();
+      const stale = !countdownStartAt || now - countdownStartAt > COUNTDOWN_WINDOW_MS * 5;
+      if (!stale) return; // already armed (or only slightly in past for rejoin)
+
+      countdownStartAt = Date.now() + COUNTDOWN_WINDOW_MS;
+      try {
+        console.log(`[flow] arm countdown | code=${code} round=${round} role=${myRole}`);
+        await updateDoc(rRef, {
+          state: "countdown",
+          round,
+          "countdown.startAt": countdownStartAt,
+          "timestamps.updatedAt": serverTimestamp()
+        });
+      } catch (err) {
+        console.warn("[countdown] failed to arm timer:", err);
       }
+    };
+
+    await armCountdownIfNeeded();
+
+    const stop = onSnapshot(rRef, (snap) => {
+      const data = snap.data() || {};
+
+      if (Number(data.round) && Number(data.round) !== round) {
+        round = Number(data.round);
+        title.textContent = `Round ${round}`;
+      }
+
+      const remoteStart = Number(data?.countdown?.startAt || 0) || 0;
+      if (remoteStart && remoteStart !== countdownStartAt) {
+        countdownStartAt = remoteStart;
+      }
+
+      if (data.state === "questions") {
+        setTimeout(() => {
+          location.hash = `#/questions?code=${code}&round=${round}`;
+        }, 80);
+        return;
+      }
+
+      if (data.state && data.state !== "countdown") {
+        // Fallback routing if we landed late
+        let target = null;
+        if (data.state === "marking") target = `#/marking?code=${code}&round=${round}`;
+        else if (data.state === "award") target = `#/award?code=${code}&round=${round}`;
+        else if (data.state === "maths") target = `#/maths?code=${code}`;
+        else if (data.state === "final") target = `#/final?code=${code}`;
+        if (target) {
+          setTimeout(() => { location.hash = target; }, 80);
+        }
+        return;
+      }
+
+      if (!remoteStart) {
+        sub.textContent = myRole === "host"
+          ? "Pressing go…"
+          : "Waiting for Daniel to arm the timer…";
+        armCountdownIfNeeded();
+      } else {
+        sub.textContent = "";
+      }
+    }, (err) => {
+      console.warn("[countdown] snapshot error:", err);
     });
 
-    // Timer (30s). Host drives next phase.
-    const startAt = Date.now();
     const tick = setInterval(async () => {
-      const remain = Math.max(0, (startAt + AWARD_WINDOW_MS) - Date.now());
-      const sec = Math.ceil(remain / 1000);
-      timerBadge.textContent = String(sec);
+      if (!countdownStartAt) {
+        timer.textContent = "—";
+        return;
+      }
 
-      if (remain <= 0) {
-        clearInterval(tick);
+      const now = Date.now();
+      const remainMs = Math.max(0, (countdownStartAt) - now);
+      const secs = Math.ceil(remainMs / 1000);
+      timer.textContent = String(secs > 0 ? secs : 0);
 
+      if (remainMs <= 0 && !hasFlipped) {
+        hasFlipped = true;
         if (myRole === "host") {
           try {
-            if (round >= 5) {
-              // Final award -> maths
-              await updateDoc(rRef, {
-                state: "maths",
-                "timestamps.updatedAt": serverTimestamp()
-              });
-            } else {
-              // Arm a 3s automatic countdown for next round
-              const nextRound = round + 1;
-              const startTs = Date.now() + 3000;
-              await updateDoc(rRef, {
-                state: "countdown",
-                round: nextRound,
-                countdown: { startAt: startTs },
-                "timestamps.updatedAt": serverTimestamp()
-              });
-            }
-          } catch (e) {
-            console.warn("[award] host flip failed:", e);
+            console.log(`[flow] countdown -> questions | code=${code} round=${round} role=${myRole}`);
+            await updateDoc(rRef, {
+              state: "questions",
+              "countdown.startAt": null,
+              "timestamps.updatedAt": serverTimestamp()
+            });
+          } catch (err) {
+            console.warn("[countdown] failed to flip to questions:", err);
+            hasFlipped = false; // allow retry
           }
         }
       }
     }, 200);
 
-    this.unmount = () => { try { stop(); } catch{} try { clearInterval(tick); } catch{} };
+    this.unmount = () => {
+      try { stop && stop(); } catch {}
+      try { clearInterval(tick); } catch {}
+    };
   },
 
-  async unmount(){ /* no-op */ }
+  async unmount() { /* handled in instance */ }
 };

--- a/Jemima-main/src/views/Maths.js
+++ b/Jemima-main/src/views/Maths.js
@@ -144,6 +144,7 @@ export default {
       patch["timestamps.updatedAt"] = serverTimestamp();
 
       try {
+        console.log(`[flow] submit maths | code=${code} role=${myRole}`);
         await updateDoc(rRef, patch);
         done.disabled = true;
         done.classList.remove("throb");

--- a/Jemima-main/src/views/Questions.js
+++ b/Jemima-main/src/views/Questions.js
@@ -1,30 +1,22 @@
 // /src/views/Questions.js
 //
-// Questions — fully local until the 3rd selection.
-// • Shows 3 questions (one at a time) with TWO big choice buttons (A/B are not shown).
-// • Counter "n / 3" at top of card. No helper text.
-// • On each click: auto-advance. On 3rd click: write answers once.
-// • After write: player waits; HOST flips state → "marking" when both have submitted.
-// • Jemima’s Maths box pinned below (inverted scheme).
-//
-// Query: ?code=ABC&round=N
-//
-// Firestore reads:
-//   rooms/{code}                 -> meta(hostUid,guestUid), answers.*, state
-//   rooms/{code}/rounds/{round}  -> hostItems/guestItems
-//
-// Firestore writes (on 3rd selection):
-//   answers.{role}.{round} = [ { chosen }, { chosen }, { chosen } ]
-//   timestamps.updatedAt
-//
-// Navigation:
-//   - When HOST detects both answers.* present, sets state:"marking" (idempotent).
-//   - Both navigate to /marking?code=...&round=N
+// Questions phase — local-only until the 3rd selection.
+// • Shows exactly the player’s three questions from rooms/{code}/rounds/{round}/{role}Items.
+// • Two large buttons per question. Selecting the 3rd answer auto-submits once.
+// • Submission writes answers.{role}.{round} = [{ chosen }, …] and timestamps.updatedAt.
+// • Host watches both submissions and flips state → "marking".
+// • Local UI keeps selections in memory only; Firestore only written on submission.
 
 import {
-  initFirebase, ensureAuth,
-  roomRef, roundSubColRef, doc,
-  getDoc, updateDoc, onSnapshot, serverTimestamp
+  initFirebase,
+  ensureAuth,
+  roomRef,
+  roundSubColRef,
+  doc,
+  getDoc,
+  updateDoc,
+  onSnapshot,
+  serverTimestamp
 } from "../lib/firebase.js";
 
 import * as MathsPaneMod from "../lib/MathsPane.js";
@@ -35,8 +27,8 @@ const mountMathsPane =
    null);
 
 const qs = () => new URLSearchParams((location.hash.split("?")[1] || ""));
-const clampCode = s => String(s||"").trim().toUpperCase().replace(/[^A-Z0-9]/g,"").slice(0,3);
-const roundTier = (r) => (r<=1 ? "easy" : r===2 ? "medium" : "hard"); // 1:e, 2:m, 3..5:h
+const clampCode = (s) => String(s || "").trim().toUpperCase().replace(/[^A-Z0-9]/g, "").slice(0, 3);
+const roundTier = (r) => (r <= 1 ? "easy" : r === 2 ? "medium" : "hard");
 
 function el(tag, attrs = {}, kids = []) {
   const n = document.createElement(tag);
@@ -46,134 +38,148 @@ function el(tag, attrs = {}, kids = []) {
     else if (k.startsWith("on") && typeof v === "function") n.addEventListener(k.slice(2), v);
     else n.setAttribute(k, v);
   }
-  (Array.isArray(kids) ? kids : [kids]).forEach(c =>
+  (Array.isArray(kids) ? kids : [kids]).forEach((c) =>
     n.appendChild(typeof c === "string" ? document.createTextNode(c) : c)
   );
   return n;
 }
 
-function shuffle2(a, b) { return Math.random() < 0.5 ? [a, b] : [b, a]; }
+function shuffle2(a, b) {
+  return Math.random() < 0.5 ? [a, b] : [b, a];
+}
 
 export default {
   async mount(container) {
     await initFirebase();
     const me = await ensureAuth();
 
-    const code  = clampCode(qs().get("code") || "");
+    const code = clampCode(qs().get("code") || "");
     const round = parseInt(qs().get("round") || "1", 10) || 1;
 
-    // Per-view ink hue
-    const hue = Math.floor(Math.random()*360);
+    const hue = Math.floor(Math.random() * 360);
     document.documentElement.style.setProperty("--ink-h", String(hue));
 
-    // Skeleton
     container.innerHTML = "";
-    const root = el("div", { class:"view view-questions" });
-    root.appendChild(el("h1", { class:"title" }, `Round ${round}`));
+    const root = el("div", { class: "view view-questions" });
+    root.appendChild(el("h1", { class: "title" }, `Round ${round}`));
 
-    const card = el("div", { class:"card" });
-    const topRow = el("div", { class:"mono", style:"display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;" });
+    const card = el("div", { class: "card" });
+    const topRow = el("div", { class: "mono", style: "display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;" });
     const roomTag = el("div", {}, `Room ${code}`);
-    const counter = el("div", { class:"mono" }, "1 / 3");
+    const counter = el("div", { class: "mono" }, "1 / 3");
     topRow.appendChild(roomTag);
     topRow.appendChild(counter);
     card.appendChild(topRow);
 
-    const qText = el("div", { class:"mono", style:"font-weight:600; white-space:pre-wrap; min-height:56px;" }, "");
+    const qText = el("div", { class: "mono", style: "font-weight:600; white-space:pre-wrap; min-height:56px;" }, "");
     card.appendChild(qText);
 
-    const btnWrap = el("div", { style:"display:flex;gap:10px;justify-content:center;margin-top:12px;flex-wrap:wrap;" });
-    const btn1 = el("button", { class:"btn big outline" }, "");
-    const btn2 = el("button", { class:"btn big outline" }, "");
+    const btnWrap = el("div", { style: "display:flex;gap:10px;justify-content:center;margin-top:12px;flex-wrap:wrap;" });
+    const btn1 = el("button", { class: "btn big outline" }, "");
+    const btn2 = el("button", { class: "btn big outline" }, "");
     btnWrap.appendChild(btn1);
     btnWrap.appendChild(btn2);
     card.appendChild(btnWrap);
 
-    const waitMsg = el("div", { class:"mono", style:"text-align:center;opacity:.8;margin-top:12px;display:none;" }, "Waiting for opponent…");
+    const waitMsg = el("div", { class: "mono", style: "text-align:center;opacity:.8;margin-top:12px;display:none;" }, "Waiting for opponent…");
     card.appendChild(waitMsg);
 
     root.appendChild(card);
 
-    // Maths pinned
-    const mathsMount = el("div", { class:"jemima-maths-pinned" });
+    const mathsMount = el("div", { class: "jemima-maths-pinned" });
     root.appendChild(mathsMount);
 
     container.appendChild(root);
 
-    // Firestore refs
-    const rRef  = roomRef(code);
-    const r1Ref = doc(roundSubColRef(code), String(round));
+    const rRef = roomRef(code);
+    const rdRef = doc(roundSubColRef(code), String(round));
 
-    // Determine role
     const roomSnap0 = await getDoc(rRef);
     const room0 = roomSnap0.data() || {};
     const { hostUid, guestUid } = room0.meta || {};
-    const myRole  = (hostUid === me.uid) ? "host" : (guestUid === me.uid) ? "guest" : "guest";
+    const myRole = hostUid === me.uid ? "host" : guestUid === me.uid ? "guest" : "guest";
     const oppRole = myRole === "host" ? "guest" : "host";
 
-    // Mount maths pane
-    try { if (mountMathsPane && room0.maths) mountMathsPane(mathsMount, { maths: room0.maths, round, mode:"inline" }); }
-    catch(e){ console.warn("[questions] MathsPane mount failed:", e); }
-
-    // Get items; choose distractor by round tier; build 3 cards in memory
-    const rd = (await getDoc(r1Ref)).data() || {};
-    const myItems = (myRole === "host" ? rd.hostItems : rd.guestItems) || [];
-
-    // Early exit if already answered (refresh flow): show wait UI, no buttons
-    const existingAns = (((room0.answers||{})[myRole]||{})[round] || []);
-    if (existingAns.length === 3) {
-      btn1.style.display = "none";
-      btn2.style.display = "none";
-      counter.textContent = "3 / 3";
-      const i0 = 2;
-      const q0 = myItems[i0]?.question || "(already submitted)";
-      qText.textContent = q0;
-      waitMsg.style.display = "";
+    try {
+      if (mountMathsPane && room0.maths) {
+        mountMathsPane(mathsMount, { maths: room0.maths, round, mode: "inline" });
+      }
+    } catch (err) {
+      console.warn("[questions] MathsPane mount failed:", err);
     }
 
-    // Prepare runtime choices for 3 questions
+    const rdSnap = await getDoc(rdRef);
+    const rd = rdSnap.data() || {};
+    const myItems = (myRole === "host" ? rd.hostItems : rd.guestItems) || [];
+
+    const existingAns = (((room0.answers || {})[myRole] || {})[round] || []);
+
     const tier = roundTier(round);
-    const triplet = [0,1,2].map(i => {
+    const triplet = [0, 1, 2].map((i) => {
       const it = myItems[i] || {};
       const correct = it.correct_answer || "";
-      const distractors = (it.distractors || {});
+      const distractors = it.distractors || {};
       const wrong = distractors[tier] || distractors.medium || distractors.easy || distractors.hard || "";
       const [optA, optB] = shuffle2(correct, wrong);
-      return { question: (it.question || ""), options: [optA, optB], correct };
+      return { question: it.question || "", options: [optA, optB], correct };
     });
 
     let idx = 0;
-    const chosen = []; // strings
+    const chosen = [];
+    let published = false;
+    let submitting = false;
+
+    const setButtonsEnabled = (enabled) => {
+      btn1.disabled = !enabled;
+      btn2.disabled = !enabled;
+      btn1.classList.toggle("throb", enabled);
+      btn2.classList.toggle("throb", enabled);
+    };
 
     function renderIndex() {
-      counter.textContent = `${Math.min(idx+1,3)} / 3`;
       const cur = triplet[idx];
+      counter.textContent = `${Math.min(idx + 1, 3)} / 3`;
       qText.textContent = cur?.question || "";
       btn1.textContent = cur?.options?.[0] || "";
       btn2.textContent = cur?.options?.[1] || "";
     }
 
+    const showWaitingState = (text = "Waiting for opponent…") => {
+      btnWrap.style.display = "none";
+      waitMsg.textContent = text;
+      waitMsg.style.display = "";
+      setButtonsEnabled(false);
+    };
+
     async function publishAnswers() {
+      if (submitting || published) return;
+      submitting = true;
+
+      const payload = chosen.slice(0, 3).map((v) => ({ chosen: v }));
+      const patch = {
+        [`answers.${myRole}.${round}`]: payload,
+        "timestamps.updatedAt": serverTimestamp()
+      };
+
       try {
-        await updateDoc(rRef, {
-          [`answers.${myRole}.${round}`]: chosen.slice(0,3).map(v => ({ chosen: v })),
-          "timestamps.updatedAt": serverTimestamp()
-        });
-        // Switch to waiting
-        btn1.style.display = "none";
-        btn2.style.display = "none";
-        waitMsg.style.display = "";
-      } catch (e) {
-        console.warn("[questions] publish failed:", e);
-        // allow a retry attempt (user could click again on hidden buttons? keep minimal—do nothing)
+        console.log(`[flow] submit answers | code=${code} round=${round} role=${myRole}`);
+        await updateDoc(rRef, patch);
+        published = true;
+        showWaitingState();
+      } catch (err) {
+        console.warn("[questions] publish failed:", err);
+        submitting = false;
+        setButtonsEnabled(true);
       }
     }
 
     function onPick(text) {
+      if (published || submitting) return;
       chosen[idx] = text;
       idx += 1;
       if (idx >= 3) {
         counter.textContent = "3 / 3";
+        setButtonsEnabled(false);
         publishAnswers();
       } else {
         renderIndex();
@@ -183,33 +189,62 @@ export default {
     btn1.addEventListener("click", () => onPick(btn1.textContent));
     btn2.addEventListener("click", () => onPick(btn2.textContent));
 
-    if (existingAns.length !== 3) {
+    if (existingAns.length === 3) {
+      published = true;
+      showWaitingState("Submitted. Waiting for opponent…");
+      counter.textContent = "3 / 3";
+      qText.textContent = triplet[2]?.question || "";
+    } else {
+      btnWrap.style.display = "flex";
+      waitMsg.style.display = "none";
+      setButtonsEnabled(true);
       renderIndex();
     }
 
-    // Watch room: HOST flips to marking once both are in
-    const stop = onSnapshot(rRef, async (s) => {
-      const d = s.data() || {};
-      // Navigate if state already flipped (e.g., host moved us)
-      if (d.state === "marking") {
-        setTimeout(() => { location.hash = `#/marking?code=${code}&round=${round}`; }, 80);
+    const stop = onSnapshot(rRef, async (snap) => {
+      const data = snap.data() || {};
+
+      if (data.state === "marking") {
+        setTimeout(() => {
+          location.hash = `#/marking?code=${code}&round=${round}`;
+        }, 80);
         return;
       }
 
-      if (myRole === "host") {
-        const myDone  = Array.isArray(((d.answers||{})[myRole]  || {})[round]) && (((d.answers||{})[myRole]  || {})[round]).length === 3;
-        const oppDone = Array.isArray(((d.answers||{})[oppRole] || {})[round]) && (((d.answers||{})[oppRole] || {})[round]).length === 3;
-        if (myDone && oppDone && d.state !== "marking") {
+      if (data.state === "countdown") {
+        setTimeout(() => {
+          location.hash = `#/countdown?code=${code}&round=${data.round || round}`;
+        }, 80);
+        return;
+      }
+
+      if (data.state === "award") {
+        setTimeout(() => {
+          location.hash = `#/award?code=${code}&round=${round}`;
+        }, 80);
+      }
+
+      // Host monitors opponent completion to flip state (idempotent)
+      if (myRole === "host" && data.state === "questions") {
+        const myDone = Array.isArray(((data.answers || {})[myRole] || {})[round]) && (((data.answers || {})[myRole] || {})[round]).length === 3;
+        const oppDone = Array.isArray(((data.answers || {})[oppRole] || {})[round]) && (((data.answers || {})[oppRole] || {})[round]).length === 3;
+        if (myDone && oppDone) {
           try {
-            await updateDoc(rRef, { state:"marking", "timestamps.updatedAt": serverTimestamp() });
-          } catch {}
+            console.log(`[flow] questions -> marking | code=${code} round=${round} role=${myRole}`);
+            await updateDoc(rRef, { state: "marking", "timestamps.updatedAt": serverTimestamp() });
+          } catch (err) {
+            console.warn("[questions] failed to flip to marking:", err);
+          }
         }
       }
+    }, (err) => {
+      console.warn("[questions] snapshot error:", err);
     });
 
-    // Unmount
-    this.unmount = () => { try { stop(); } catch {} };
+    this.unmount = () => {
+      try { stop && stop(); } catch {}
+    };
   },
 
-  async unmount(){ /* no-op */ }
+  async unmount() { /* instance handles cleanup */ }
 };


### PR DESCRIPTION
## Summary
- anchor the countdown phase to Firestore start timestamps and flip to questions only after the shared timer completes
- rebuild the award view to show role-specific results, manage the 30s timer, and arm the next round or maths phase deterministically
- harden questions and marking flows to isolate host/guest data, auto-submit once per phase, and log phase transitions for debugging

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e20aa7b00c832c928ea7145ad056ff