### PR TITLE
Implement sealed game file upload workflow

### DIFF
--- a/Jemima-main/src/lib/seedUnsealer.js
+++ b/Jemima-main/src/lib/seedUnsealer.js
@@ -1,0 +1,112 @@
+// /src/lib/seedUnsealer.js
+//
+// Example: encrypting a seed payload (run in a browser console or Node >=20)
+// ------------------------------------------------------------------------
+// const encoder = new TextEncoder();
+// const STATIC_SALT = "jemimas-asking::seed-salt";
+// async function seal(seedJson, roomCode, hostUid) {
+//   const data = encoder.encode(JSON.stringify(seedJson));
+//   const material = encoder.encode(`${roomCode}${hostUid}${STATIC_SALT}`);
+//   const digest = await crypto.subtle.digest("SHA-256", material);
+//   const key = await crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, ["encrypt"]);
+//   const iv = crypto.getRandomValues(new Uint8Array(12));
+//   const sealed = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, data);
+//   const blob = new Uint8Array(iv.byteLength + sealed.byteLength);
+//   blob.set(iv, 0);
+//   blob.set(new Uint8Array(sealed), iv.byteLength);
+//   return new Blob([blob], { type: "application/octet-stream" });
+// }
+// ------------------------------------------------------------------------
+// The host uploads the resulting blob (.sealed). The functions below derive
+// the same key and decrypt the payload entirely in-memory.
+
+const STATIC_SALT = "jemimas-asking::seed-salt";
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function getCrypto() {
+  const c = globalThis.crypto || globalThis.msCrypto;
+  if (!c || !c.subtle) {
+    throw new Error("Web Crypto API is required to unseal game files.");
+  }
+  return c;
+}
+
+function base64ToArrayBuffer(b64) {
+  const clean = String(b64 || "").trim();
+  if (!clean) throw new Error("Empty game file payload.");
+  const dataPart = clean.includes(",") ? clean.split(",").pop() : clean;
+  try {
+    if (typeof atob === "function") {
+      const bin = atob(dataPart);
+      const bytes = new Uint8Array(bin.length);
+      for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+      return bytes.buffer;
+    }
+  } catch (err) {
+    throw new Error("Game file is not valid base64 data.");
+  }
+  try {
+    const buf = Buffer.from(dataPart, "base64");
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  } catch (err) {
+    throw new Error("Game file is not valid base64 data.");
+  }
+}
+
+async function normaliseToArrayBuffer(file) {
+  if (!file) throw new Error("No game file provided.");
+  if (file instanceof ArrayBuffer) return file;
+  if (ArrayBuffer.isView(file)) return file.buffer.slice(file.byteOffset, file.byteOffset + file.byteLength);
+  if (typeof file === "string") return base64ToArrayBuffer(file);
+  if (typeof Blob !== "undefined" && file instanceof Blob) {
+    return await file.arrayBuffer();
+  }
+  if (file?.arrayBuffer instanceof Function) {
+    return await file.arrayBuffer();
+  }
+  throw new Error("Unsupported game file type.");
+}
+
+async function deriveKey(roomCode, hostUid) {
+  const code = String(roomCode || "").trim().toUpperCase();
+  const uid = String(hostUid || "").trim();
+  if (!code || !uid) throw new Error("Room code or host identity missing.");
+  const crypto = getCrypto();
+  // Combine the dynamic identifiers with the static salt, then hash via SHA-256 to obtain 256 bits of key material.
+  const material = encoder.encode(`${code}${uid}${STATIC_SALT}`);
+  const digest = await crypto.subtle.digest("SHA-256", material);
+  // Import the digest as an AES-GCM key for decryption only.
+  return crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, ["decrypt"]);
+}
+
+export async function unsealSeed(file, roomCode, hostUid) {
+  const crypto = getCrypto();
+  const key = await deriveKey(roomCode, hostUid);
+  const payload = await normaliseToArrayBuffer(file);
+  if (payload.byteLength <= 12) {
+    throw new Error("Game file is too short or missing its IV.");
+  }
+  const iv = new Uint8Array(payload.slice(0, 12));
+  const ciphertext = payload.slice(12);
+  let decrypted;
+  try {
+    // AES-GCM decrypt using the IV prepended to the payload; the mode verifies integrity via its built-in authentication tag.
+    decrypted = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, ciphertext);
+  } catch (err) {
+    throw new Error("Failed to decrypt game file. Check the room code and host account.");
+  }
+  let parsed;
+  try {
+    const json = decoder.decode(decrypted);
+    parsed = JSON.parse(json);
+  } catch (err) {
+    throw new Error("Decrypted game file is not valid JSON.");
+  }
+  if (typeof parsed !== "object" || !parsed) {
+    throw new Error("Game file payload is malformed.");
+  }
+  return parsed;
+}
+
+export default unsealSeed;

--- a/Jemima-main/src/views/KeyRoom.js
+++ b/Jemima-main/src/views/KeyRoom.js
@@ -1,9 +1,11 @@
 // /src/views/KeyRoom.js
 import {
   initFirebase, ensureAuth,
-  roomRef, getDoc, setDoc, updateDoc, serverTimestamp,
+  roomRef, roundSubColRef, doc,
+  getDoc, setDoc, updateDoc, serverTimestamp,
   claimRoleIfEmpty
 } from "../lib/firebase.js";
+import { unsealSeed } from "../lib/seedUnsealer.js";
 
 function el(tag, attrs = {}, kids = []) {
   const n = document.createElement(tag);
@@ -74,6 +76,8 @@ export default {
     jmathsIn.value = localStorage.getItem("jmathsJson") || "";
 
     const status = el("div", { class: "mono", style: "margin-top:8px; min-height:18px;" }, "");
+    const uploadBtn = el("button", { class: "btn", style: "margin-top:12px;" }, "Upload Game File");
+    const fileInput = el("input", { type: "file", accept: ".sealed,application/octet-stream", style: "display:none;" });
     const startBtn = el("button", { class: "btn throb", style: "margin-top:12px;" }, "Start seeding");
 
     // Save-on-edit
@@ -86,6 +90,8 @@ export default {
     root.appendChild(qcfgIn);
     root.appendChild(jmathsIn);
     root.appendChild(status);
+    root.appendChild(uploadBtn);
+    root.appendChild(fileInput);
     root.appendChild(startBtn);
 
     container.appendChild(root);
@@ -113,6 +119,78 @@ export default {
         status.textContent = "Host ready.";
       }
     }
+
+    // Writes the decrypted payload into Firestore, then advances the room to countdown.
+    const applySeedToFirestore = async (seedData) => {
+      const rounds = seedData?.rounds || [];
+      const maths = seedData?.maths;
+      const interludes = seedData?.interludes;
+      const roundsCol = roundSubColRef(code);
+
+      const entries = [];
+      if (Array.isArray(rounds)) {
+        rounds.forEach((round, idx) => {
+          if (round && typeof round === "object") entries.push([String(idx + 1), round]);
+        });
+      } else if (rounds && typeof rounds === "object") {
+        for (const [roundId, payload] of Object.entries(rounds)) {
+          if (payload && typeof payload === "object") entries.push([String(roundId), payload]);
+        }
+      }
+
+      if (!entries.length) {
+        throw new Error("Game file is missing round data.");
+      }
+
+      // Write each round document under rooms/{code}/rounds/{n}.
+      entries.sort((a, b) => {
+        const na = Number(a[0]);
+        const nb = Number(b[0]);
+        if (!Number.isNaN(na) && !Number.isNaN(nb)) return na - nb;
+        return String(a[0]).localeCompare(String(b[0]));
+      });
+      for (const [roundId, payload] of entries) {
+        await setDoc(doc(roundsCol, roundId), payload);
+      }
+
+      const patch = {
+        state: "countdown",
+        round: 1,
+        "countdown.startAt": null,
+        "timestamps.updatedAt": serverTimestamp()
+      };
+      if (maths && typeof maths === "object") patch.maths = maths;
+      if (typeof interludes !== "undefined") patch.interludes = interludes;
+      patch["seeds.progress"] = 100;
+      patch["seeds.message"] = "Loaded sealed game.";
+
+      await updateDoc(ref, patch);
+    };
+
+    const handleSealedUpload = async (file) => {
+      if (!file) return;
+      uploadBtn.disabled = true;
+      startBtn.disabled = true;
+      status.textContent = "Decrypting…";
+      try {
+        const seed = await unsealSeed(file, code, me.uid);
+        status.textContent = "Writing game data…";
+        // Once decrypted, populate Firestore with rounds + maths, then flip to countdown.
+        await applySeedToFirestore(seed);
+        status.textContent = "Game ready. Countdown next.";
+        location.hash = `#/countdown?code=${code}&round=1`;
+      } catch (err) {
+        console.error("[keyroom] sealed upload failed:", err);
+        status.textContent = err?.message || "Failed to load game file.";
+        uploadBtn.disabled = false;
+        startBtn.disabled = false;
+      } finally {
+        try { fileInput.value = ""; } catch {}
+      }
+    };
+
+    uploadBtn.addEventListener("click", () => fileInput.click());
+    fileInput.addEventListener("change", () => handleSealedUpload(fileInput.files?.[0]));
 
     // ----- Start seeding -> go to seeding view -----
     startBtn.addEventListener("click", async () => {


### PR DESCRIPTION
## Summary
- add a Web Crypto based seed unsealer that derives the AES key from the room and host identifiers
- extend the Key Room view with a sealed game upload flow that writes rounds, maths and interludes to Firestore
- update seeding status messaging so sealed packs flip the room straight to the countdown phase

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e765998690832cb424545f69cb8384